### PR TITLE
PressureTileEntity.java バグ修正

### DIFF
--- a/src/main/java/io/github/starmineouji/starchemical/tiles/pressure/PressureTileEntity.java
+++ b/src/main/java/io/github/starmineouji/starchemical/tiles/pressure/PressureTileEntity.java
@@ -47,13 +47,14 @@ public class PressureTileEntity extends TileEntity implements IInventory {
 		return index == 1 ? O : I;
 	}
 
-	@Override
-	public ItemStack decrStackSize(int index, int count) {
-		if (index >= 2)
-			throw new ArrayIndexOutOfBoundsException(index);
-		return index == 1 ? O = new ItemStack(O.getItem(), O.getCount() - count)
-				: (I = new ItemStack(I.getItem(), I.getCount() - count));
-	}
+    	@Override
+    	public ItemStack decrStackSize(int index, int count) {
+        	if (index >= 2) {
+            		throw new ArrayIndexOutOfBoundsException(index);
+       		}
+        	return index == 1 ? ItemStackHelper.getAndSplit(Lists.newArrayList(O), index, count) :
+                	ItemStackHelper.getAndSplit(Lists.newArrayList(I), index, count);
+    }
 
 	@Override
 	public void deserializeNBT(NBTTagCompound nbt) {


### PR DESCRIPTION
50行目～ decrStackSizeの方法が間違っておりstackSizeが0になっていたため、そのようにならないように修正しました。TileEneityFurnaceの同じメソッドを参考にしていますのでご参照ください。